### PR TITLE
Cut to new version to obey the tyranny of semver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "displaydoc"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library provides a convenient derive macro for the standard library's
 
 ```toml
 [dependencies]
-displaydoc = "0.1.3"
+displaydoc = "0.2.0"
 ```
 
 *Compiler support: requires rustc 1.31+*


### PR DESCRIPTION
I changed the name of the derive attribute from DisplayDoc to Display and didn't bump the minor version. Oops.