### PR TITLE
feat: add Display support for Path and PathBuf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "displaydoc"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ A derive macro for implementing the display Trait via a doc comment and string i
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["std"]
+std = []
 
 [dependencies]
 syn = "1.0"
@@ -28,3 +30,4 @@ trybuild = "1.0"
 static_assertions = "0.3.4"
 libc = { version = "0.2", default-features = false }
 rustversion = "1.0.0"
+pretty_assertions = "0.6.1"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This library provides a convenient derive macro for the standard library's
 
 ```toml
 [dependencies]
-displaydoc = "0.1.4"
+displaydoc = "0.1"
 ```
 
 *Compiler support: requires rustc 1.31+*
@@ -61,6 +61,9 @@ pub enum DataStoreError {
 
 1. **Is this crate `no_std` compatible?**
     * Yes! This crate implements the `core::fmt::Display` trait not the `std::fmt::Display` trait so it should work in `std` and `no_std` environments.
+
+2. **Does this crate work with `Path` and `PathBuf` via the `Display` trait?**
+    * Yuuup. This crate uses @dtolnay's [autoref specialization technique](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md) to add a special trait for types to get the display impl, it then specializes for `Path` and `PathBuf` and when either of these types are found it calls `self.display()` to get a `std::path::Display<'_>` type which can be used with the Display format specifier!
 
 <br>
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -111,13 +111,18 @@ mod tests {
 
     #[test]
     fn test_expand() {
-        assert("error {var}", "error {}", ", ( & var ) . get_display ( )");
         assert("fn main() {{ }}", "fn main() {{ }}", "");
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "std"), ignore)]
+    fn test_std_expand() {
         assert(
             "{v} {v:?} {0} {0:?}",
             "{} {:?} {} {:?}",
             ", ( & v ) . get_display ( ) , v , ( & _0 ) . get_display ( ) , _0",
         );
+        assert("error {var}", "error {}", ", ( & var ) . get_display ( )");
 
         // assert("The path {0.display()}", "The path {}", "0.display()");
         // assert("The path {0.display():?}", "The path {:?}", "0.display()");

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -41,7 +41,7 @@ impl Display {
                 None => return,
             };
 
-            let arg = if next == '}' {
+            let arg = if core::cfg!(feature = "std") && next == '}' {
                 quote_spanned!(span=> , (&#ident).get_display())
             } else {
                 quote_spanned!(span=> , #ident)

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -1,4 +1,6 @@
+#[allow(unused_attributes)]
 #[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(feature = "std", ignore)]
 #[test]
 fn no_std() {
     let t = trybuild::TestCases::new();

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -1,4 +1,5 @@
 use displaydoc::Display;
+// use std::path::PathBuf;
 
 #[derive(Display)]
 enum Happy {
@@ -17,6 +18,8 @@ enum Happy {
     /// Variant5 just has {0} many problems
     /// but multi line comments aren't one of them
     Variant5(u32),
+    // /// The path {0.display()}
+    // Variant6(PathBuf),
 }
 
 fn assert_display<T: std::fmt::Display>(input: T, expected: &'static str) {
@@ -34,4 +37,8 @@ fn does_it_print() {
         "Variant4 wants to have a lot of lines\n\n Lets see how this works out for it",
     );
     assert_display(Happy::Variant5(2), "Variant5 just has 2 many problems");
+    // assert_display(
+    //     Happy::Variant6(PathBuf::from("/var/log/happy")),
+    //     "The path /var/log/happy",
+    // );
 }


### PR DESCRIPTION
Prior to this change, we could not display Paths or PathBufs via display
and their `Path::display` function because we only support identifiers
in the formatting strings and don't do anything fancy with those args
other than paste them verbatim into the args for the generated `write!`
calls.

This change adds special support for Path and PathBuf displaying via
autoref specialization. We introduce two new traits, one which handles
anything that implements display and just returns self, and another
which specifically works for Path and PathBuf and returns
`std::path::Display`. On top of this we manually route all display impl
format args thru this trait by putting `(&arg).get_display()` rather
than `arg` in the generated format args list.

closes #4