### PR TITLE
Hide helper traits from calling code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: Continuous integration
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -11,8 +11,10 @@ pub fn derive(input: &DeriveInput) -> Result<TokenStream> {
     }?;
 
     let helpers = specialization();
+    let dummy_const = format_ident!("_DERIVE_Display_FOR_{}", input.ident);
     Ok(quote! {
-        const _: () = {
+        #[allow(non_upper_case_globals, unused_attributes, unused_qualifications)]
+        const #dummy_const: () = {
             #helpers
             #impls
         };

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -1,5 +1,13 @@
 use displaydoc::Display;
-// use std::path::PathBuf;
+
+#[cfg(feature = "std")]
+use std::path::PathBuf;
+
+#[derive(Display)]
+/// Just a basic struct {thing}
+struct HappyStruct {
+    thing: &'static str,
+}
 
 #[derive(Display)]
 enum Happy {
@@ -18,8 +26,10 @@ enum Happy {
     /// Variant5 just has {0} many problems
     /// but multi line comments aren't one of them
     Variant5(u32),
-    // /// The path {0.display()}
-    // Variant6(PathBuf),
+
+    /// The path {0}
+    #[cfg(feature = "std")]
+    Variant6(PathBuf),
 }
 
 fn assert_display<T: std::fmt::Display>(input: T, expected: &'static str) {
@@ -37,8 +47,15 @@ fn does_it_print() {
         "Variant4 wants to have a lot of lines\n\n Lets see how this works out for it",
     );
     assert_display(Happy::Variant5(2), "Variant5 just has 2 many problems");
-    // assert_display(
-    //     Happy::Variant6(PathBuf::from("/var/log/happy")),
-    //     "The path /var/log/happy",
-    // );
+
+    assert_display(HappyStruct { thing: "hi" }, "Just a basic struct hi");
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn does_it_print_path() {
+    assert_display(
+        Happy::Variant6(PathBuf::from("/var/log/happy")),
+        "The path /var/log/happy",
+    );
 }


### PR DESCRIPTION
Changes the name of the `Display` trait method to reduce the chance that an inherent method conflicts with the type in question, and wraps the helper trait and declarations into an anonymous const context, meaning the helper traits aren't visible to the calling context.