### PR TITLE
Add a simple example

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,36 @@
+use displaydoc::Display;
+
+#[derive(Debug, Display)]
+pub enum DataStoreError {
+    /// data store disconnected
+    Disconnect,
+    /// the data for key `{0}` is not available
+    Redaction(String),
+    /// invalid header (expected {expected:?}, found {found:?})
+    InvalidHeader { expected: String, found: String },
+    /// unknown data store error
+    Unknown,
+}
+
+fn main() {
+    let disconnect = DataStoreError::Disconnect;
+    println!(
+        "Enum value `Disconnect` should be printed as:\n\t{}",
+        disconnect
+    );
+
+    let redaction = DataStoreError::Redaction(String::from("Dummy"));
+    println!(
+        "Enum value `Redaction` should be printed as:\n\t{}",
+        redaction
+    );
+
+    let invalid_header = DataStoreError::InvalidHeader {
+        expected: String::from("https"),
+        found: String::from("http"),
+    };
+    println!(
+        "Enum value `InvalidHeader` should be printed as:\n\t{}",
+        invalid_header
+    );
+}


### PR DESCRIPTION
Hello, I tries to add a simple example for fixing Issue #5 .

After running `cargo run --example simple`, the result is printed like:

```
Enum value `Disconnect` should be printed as:
	data store disconnected
Enum value `Redaction` should be printed as:
	the data for key `Dummy` is not available
Enum value `InvalidHeader` should be printed as:
	invalid header (expected "https", found "http")
```