### PR TITLE
fix: reintroduce autoref specialization

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -25,11 +25,11 @@ pub fn derive(input: &DeriveInput) -> Result<TokenStream> {
 fn specialization() -> TokenStream {
     quote! {
         trait DisplayToDisplayDoc {
-            fn __displaydoc_display(&self) -> &Self;
+            fn __displaydoc_display(&self) -> Self;
         }
 
-        impl<T: core::fmt::Display> DisplayToDisplayDoc for T {
-            fn __displaydoc_display(&self) -> &Self {
+        impl<T: core::fmt::Display> DisplayToDisplayDoc for &T {
+            fn __displaydoc_display(&self) -> Self {
                 self
             }
         }


### PR DESCRIPTION
Prior to this change, we reorganized the code to make certain that none
of the types we introduce for autoref specialization would leak into the
public interface. In the process of doing so it seems that the default
trait for Display types was modified to no longer be implemented &T and
was intead implemented for T. This means that both the default and the
specialized form of the ToDisplay trait were at the same ref level. If
Path and PathBuf ever got a Display impl added in the future this would
become ambiguous and would no longer compile.

This change fixes the signature back to what it was intended to be, with
&T being at a lower priority than T, so that there is no ambiguity and
autoref specialization will pic the specialized Display impl for Path
and PathBuf over the T: Display impl if both exist.