### PR TITLE
Slightly document std feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pub enum DataStoreError {
 ## FAQ
 
 1. **Is this crate `no_std` compatible?**
-    * Yes! This crate implements the `core::fmt::Display` trait not the `std::fmt::Display` trait so it should work in `std` and `no_std` environments.
+    * Yes! This crate implements the `core::fmt::Display` trait not the `std::fmt::Display` trait so it should work in `std` and `no_std` environments. Just add `default-features = false`.
 
 2. **Does this crate work with `Path` and `PathBuf` via the `Display` trait?**
     * Yuuup. This crate uses @dtolnay's [autoref specialization technique](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md) to add a special trait for types to get the display impl, it then specializes for `Path` and `PathBuf` and when either of these types are found it calls `self.display()` to get a `std::path::Display<'_>` type which can be used with the Display format specifier!


### PR DESCRIPTION
Seems to have been added/required for `Path(buf)` stuff, but breaks no_std by default, which confused me before I thought to check for features.