### PR TITLE
Panic when encountering unsupported multi-line comments

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -23,7 +23,7 @@ pub fn display(attrs: &[Attribute]) -> Result<Option<Display>> {
         .filter(|attr| attr.path.is_ident("doc"))
         .count();
     if num_doc_attrs > 1 {
-        panic!("Multi-line comments are not currently supported by displaydoc. Please consider using block comments (/** */)");
+        panic!("Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)");
     }
 
     for attr in attrs {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -18,6 +18,14 @@ impl ToTokens for Display {
 }
 
 pub fn display(attrs: &[Attribute]) -> Result<Option<Display>> {
+    let num_doc_attrs = attrs
+        .iter()
+        .filter(|attr| attr.path.is_ident("doc"))
+        .count();
+    if num_doc_attrs > 1 {
+        panic!("Multi-line comments are not currently supported by displaydoc. Please consider using block comments (/** */)");
+    }
+
     for attr in attrs {
         if attr.path.is_ident("doc") {
             let meta = attr.parse_meta()?;

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -5,8 +5,12 @@ fn no_std() {
     let t = trybuild::TestCases::new();
     #[cfg(not(feature = "std"))]
     t.compile_fail("tests/no_std/without.rs");
+    #[cfg(not(feature = "std"))]
+    t.compile_fail("tests/no_std/multi_line.rs");
     #[cfg(feature = "std")]
     t.compile_fail("tests/std/without.rs");
+    #[cfg(feature = "std")]
+    t.compile_fail("tests/std/multi_line.rs");
     #[cfg(feature = "std")]
     t.pass("tests/std/multiple.rs");
     t.pass("tests/no_std/with.rs");

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -23,8 +23,8 @@ enum Happy {
      * Lets see how this works out for it
      */
     Variant4,
-    /// Variant5 just has {0} many problems
-    /// but multi line comments aren't one of them
+    /// Variant5 has a parameter {0} and some regular comments
+    // A regular comment that won't get picked
     Variant5(u32),
 
     /// The path {0}
@@ -86,7 +86,10 @@ fn does_it_print() {
         Happy::Variant4,
         "Variant4 wants to have a lot of lines\n\nLets see how this works out for it",
     );
-    assert_display(Happy::Variant5(2), "Variant5 just has 2 many problems");
+    assert_display(
+        Happy::Variant5(2),
+        "Variant5 has a parameter 2 and some regular comments",
+    );
 
     assert_display(HappyStruct { thing: "hi" }, "Just a basic struct hi");
 

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -50,8 +50,8 @@ mod inner_mod {
          * Lets see how this works out for it
          */
         Variant4,
-        /// Variant5 just has {0} many problems
-        /// but multi line comments aren't one of them
+        /// Variant5 has a parameter {0} and some regular comments
+        // A regular comment that won't get picked
         Variant5(u32),
 
         /** what happens if we
@@ -108,7 +108,7 @@ fn does_it_print() {
     );
     assert_display(
         inner_mod::InnerHappy::Variant5(2),
-        "Variant5 just has 2 many problems",
+        "Variant5 has a parameter 2 and some regular comments",
     );
     assert_display(
         inner_mod::InnerHappy::Variant6,

--- a/tests/no_std/multi_line.rs
+++ b/tests/no_std/multi_line.rs
@@ -1,0 +1,37 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+/// this type is pretty swell
+#[derive(Display)]
+enum TestType {
+    /// This one is okay
+    Variant1,
+
+    /// Multi
+    /// line
+    /// doc.
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/no_std/multi_line.stderr
+++ b/tests/no_std/multi_line.stderr
@@ -1,0 +1,19 @@
+error: proc-macro derive panicked
+  --> $DIR/multi_line.rs:23:10
+   |
+23 | #[derive(Display)]
+   |          ^^^^^^^
+   |
+   = help: message: Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)
+
+error[E0277]: `TestType` doesn't implement `Display`
+  --> $DIR/multi_line.rs:34:44
+   |
+34 | static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+   | -------------------------------------------^^^^^^^^----------------------
+   | |                                          |
+   | |                                          `TestType` cannot be formatted with the default formatter
+   | required by this bound in `assert_impl_all`
+   |
+   = help: the trait `Display` is not implemented for `TestType`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/tests/std/multi_line.rs
+++ b/tests/std/multi_line.rs
@@ -1,0 +1,1 @@
+../no_std/multi_line.rs

--- a/tests/std/multi_line.stderr
+++ b/tests/std/multi_line.stderr
@@ -1,0 +1,19 @@
+error: proc-macro derive panicked
+  --> $DIR/multi_line.rs:23:10
+   |
+23 | #[derive(Display)]
+   |          ^^^^^^^
+   |
+   = help: message: Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)
+
+error[E0277]: `TestType` doesn't implement `std::fmt::Display`
+  --> $DIR/multi_line.rs:34:44
+   |
+34 | static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+   | -------------------------------------------^^^^^^^^----------------------
+   | |                                          |
+   | |                                          `TestType` cannot be formatted with the default formatter
+   | required by this bound in `assert_impl_all`
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `TestType`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead


### PR DESCRIPTION
Hello!

We ran into an issue where we had a doc-comment that looked something like this:
```
/// There was an issue with the forbnicator.
/// The request was: {0}
Frob(String),
```

We learned that hard ware that `displaydoc` only picks the first comment, and then saw https://github.com/yaahc/displaydoc/issues/16. We proceeded to change all of our multi-line doc comments to use the `/** */` style comments, and in order to find all of them we used the patch presented here.

Would you consider merging this or some version of this (perhaps behind a feature flag that allows disabling it, or selectively enabling)? The result of us mistakenly using an implicitly unsupported doc-comment was that we missed a valuable log message, so I would say this is an important issue for our use.

Thank you!