### PR TITLE
Allow multi line doc comments with an attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+# Added
+- Added opt in support for ignoring extra doc attributes
 
 ## [0.2.0] - 2021-03-16
 # Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+## [0.2.1] - 2021-03-26
 # Added
 - Added opt in support for ignoring extra doc attributes
 
@@ -21,5 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lines are needed.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/yaahc/displaydoc/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/yaahc/displaydoc/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/yaahc/displaydoc/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/yaahc/displaydoc/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,15 +62,16 @@ search="<!-- next-header -->"
 replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate"
 exactly=1
 
-[[package.metadata.release.pre-release-replacements]]
-file="CHANGELOG.md"
-search="<!-- next-url -->"
-replace="<!-- next-url -->\n[Unreleased]: https://github.com/yaahc/{{crate_name}}/compare/{{tag_name}}...HEAD"
-exactly=1
-
 # Disable this replacement on the very first release
 [[package.metadata.release.pre-release-replacements]]
 file = "CHANGELOG.md"
 search = "\\.\\.\\.HEAD"
 replace="...{{tag_name}}"
 exactly = 1
+# END SECTION, do not comment out the replacement below this, and do not reorder them
+
+[[package.metadata.release.pre-release-replacements]]
+file="CHANGELOG.md"
+search="<!-- next-url -->"
+replace="<!-- next-url -->\n[Unreleased]: https://github.com/yaahc/{{crate_name}}/compare/{{tag_name}}...HEAD"
+exactly=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = "1.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-syn = "1.0"
+syn = { version = "1.0", features = ["extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "displaydoc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -17,46 +17,60 @@ impl ToTokens for Display {
     }
 }
 
-pub(crate) fn display(attrs: &[Attribute]) -> Result<Option<Display>> {
-    let num_doc_attrs = attrs
-        .iter()
-        .filter(|attr| attr.path.is_ident("doc"))
-        .count();
+pub(crate) struct AttrsHelper {
+    allow_multi_line: bool,
+}
 
-    if num_doc_attrs > 1 {
-        panic!("Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)");
+impl AttrsHelper {
+    pub(crate) fn new(attrs: &[Attribute]) -> Self {
+        let allow_multi_line = attrs
+            .iter()
+            .any(|attr| attr.path.is_ident("allow_multi_line"));
+
+        Self { allow_multi_line }
     }
 
-    for attr in attrs {
-        if attr.path.is_ident("doc") {
-            let meta = attr.parse_meta()?;
-            let lit = match meta {
-                Meta::NameValue(syn::MetaNameValue {
-                    lit: syn::Lit::Str(lit),
-                    ..
-                }) => lit,
-                _ => unimplemented!(),
-            };
+    pub(crate) fn display(&self, attrs: &[Attribute]) -> Result<Option<Display>> {
+        let num_doc_attrs = attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident("doc"))
+            .count();
 
-            // Make an attempt and cleaning up multiline doc comments
-            let doc_str = lit
-                .value()
-                .lines()
-                .map(|line| line.trim().trim_start_matches('*').trim())
-                .collect::<Vec<&str>>()
-                .join("\n");
-
-            let lit = LitStr::new(doc_str.trim(), lit.span());
-
-            let mut display = Display {
-                fmt: lit,
-                args: TokenStream::new(),
-            };
-
-            display.expand_shorthand();
-            return Ok(Some(display));
+        if !self.allow_multi_line && num_doc_attrs > 1 {
+            panic!("Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)");
         }
-    }
 
-    Ok(None)
+        for attr in attrs {
+            if attr.path.is_ident("doc") {
+                let meta = attr.parse_meta()?;
+                let lit = match meta {
+                    Meta::NameValue(syn::MetaNameValue {
+                        lit: syn::Lit::Str(lit),
+                        ..
+                    }) => lit,
+                    _ => unimplemented!(),
+                };
+
+                // Make an attempt and cleaning up multiline doc comments
+                let doc_str = lit
+                    .value()
+                    .lines()
+                    .map(|line| line.trim().trim_start_matches('*').trim())
+                    .collect::<Vec<&str>>()
+                    .join("\n");
+
+                let lit = LitStr::new(doc_str.trim(), lit.span());
+
+                let mut display = Display {
+                    fmt: lit,
+                    args: TokenStream::new(),
+                };
+
+                display.expand_shorthand();
+                return Ok(Some(display));
+            }
+        }
+
+        Ok(None)
+    }
 }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -18,16 +18,18 @@ impl ToTokens for Display {
 }
 
 pub(crate) struct AttrsHelper {
-    ignore_multi_line: bool,
+    ignore_extra_doc_attributes: bool,
 }
 
 impl AttrsHelper {
     pub(crate) fn new(attrs: &[Attribute]) -> Self {
-        let ignore_multi_line = attrs
+        let ignore_extra_doc_attributes = attrs
             .iter()
-            .any(|attr| attr.path.is_ident("ignore_multi_line"));
+            .any(|attr| attr.path.is_ident("ignore_extra_doc_attributes"));
 
-        Self { ignore_multi_line }
+        Self {
+            ignore_extra_doc_attributes,
+        }
     }
 
     pub(crate) fn display(&self, attrs: &[Attribute]) -> Result<Option<Display>> {
@@ -36,8 +38,8 @@ impl AttrsHelper {
             .filter(|attr| attr.path.is_ident("doc"))
             .count();
 
-        if !self.ignore_multi_line && num_doc_attrs > 1 {
-            panic!("Multi-line comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_multi_line] attribute to your type next to the derive.");
+        if !self.ignore_extra_doc_attributes && num_doc_attrs > 1 {
+            panic!("Multi-line comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive.");
         }
 
         for attr in attrs {

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -18,16 +18,16 @@ impl ToTokens for Display {
 }
 
 pub(crate) struct AttrsHelper {
-    allow_multi_line: bool,
+    ignore_multi_line: bool,
 }
 
 impl AttrsHelper {
     pub(crate) fn new(attrs: &[Attribute]) -> Self {
-        let allow_multi_line = attrs
+        let ignore_multi_line = attrs
             .iter()
-            .any(|attr| attr.path.is_ident("allow_multi_line"));
+            .any(|attr| attr.path.is_ident("ignore_multi_line"));
 
-        Self { allow_multi_line }
+        Self { ignore_multi_line }
     }
 
     pub(crate) fn display(&self, attrs: &[Attribute]) -> Result<Option<Display>> {
@@ -36,8 +36,8 @@ impl AttrsHelper {
             .filter(|attr| attr.path.is_ident("doc"))
             .count();
 
-        if !self.allow_multi_line && num_doc_attrs > 1 {
-            panic!("Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)");
+        if !self.ignore_multi_line && num_doc_attrs > 1 {
+            panic!("Multi-line comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_multi_line] attribute to your type next to the derive.");
         }
 
         for attr in attrs {

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,5 +1,4 @@
-use crate::attr;
-use attr::AttrsHelper;
+use super::attr::AttrsHelper;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Result};

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1,4 +1,5 @@
 use crate::attr;
+use attr::AttrsHelper;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Result};
@@ -67,7 +68,9 @@ fn impl_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
     let ty = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let display = attr::display(&input.attrs)?.map(|display| {
+    let helper = AttrsHelper::new(&input.attrs);
+
+    let display = helper.display(&input.attrs)?.map(|display| {
         let pat = match &data.fields {
             Fields::Named(fields) => {
                 let var = fields.named.iter().map(|field| &field.ident);
@@ -97,10 +100,12 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
     let ty = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
+    let helper = AttrsHelper::new(&input.attrs);
+
     let displays = data
         .variants
         .iter()
-        .map(|variant| attr::display(&variant.attrs))
+        .map(|variant| helper.display(&variant.attrs))
         .collect::<Result<Vec<_>>>()?;
 
     if displays.iter().any(Option::is_some) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derive macro for implementing `Display` via doc comment attributes
-#[proc_macro_derive(Display)]
+#[proc_macro_derive(Display, attributes(allow_multi_line))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derive macro for implementing `Display` via doc comment attributes
-#[proc_macro_derive(Display, attributes(ignore_multi_line))]
+#[proc_macro_derive(Display, attributes(ignore_extra_doc_attributes))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //!
 //! 2. **Does this crate work with `Path` and `PathBuf` via the `Display` trait?**
 //!     * Yuuup. This crate uses @dtolnay's [autoref specialization technique](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md) to add a special trait for types to get the display impl, it then specializes for `Path` and `PathBuf` and when either of these types are found it calls `self.display()` to get a `std::path::Display<'_>` type which can be used with the Display format specifier!
-#![doc(html_root_url = "https://docs.rs/displaydoc/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/displaydoc/0.2.1")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(
     rust_2018_idioms,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derive macro for implementing `Display` via doc comment attributes
-#[proc_macro_derive(Display, attributes(allow_multi_line))]
+#[proc_macro_derive(Display, attributes(ignore_multi_line))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -7,10 +7,14 @@ fn no_std() {
     t.compile_fail("tests/no_std/without.rs");
     #[cfg(not(feature = "std"))]
     t.compile_fail("tests/no_std/multi_line.rs");
+    #[cfg(not(feature = "std"))]
+    t.pass("tests/no_std/multi_line_allow.rs");
     #[cfg(feature = "std")]
     t.compile_fail("tests/std/without.rs");
     #[cfg(feature = "std")]
     t.compile_fail("tests/std/multi_line.rs");
+    #[cfg(feature = "std")]
+    t.pass("tests/std/multi_line_allow.rs");
     #[cfg(feature = "std")]
     t.pass("tests/std/multiple.rs");
     t.pass("tests/no_std/with.rs");

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -10,7 +10,7 @@ struct HappyStruct {
 }
 
 #[derive(Display)]
-#[allow_multi_line]
+#[ignore_multi_line]
 /// Just a basic struct {thing}
 /// and this line should get ignored
 struct HappyStruct2 {

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -10,7 +10,7 @@ struct HappyStruct {
 }
 
 #[derive(Display)]
-#[ignore_multi_line]
+#[ignore_extra_doc_attributes]
 /// Just a basic struct {thing}
 /// and this line should get ignored
 struct HappyStruct2 {

--- a/tests/happy.rs
+++ b/tests/happy.rs
@@ -10,6 +10,14 @@ struct HappyStruct {
 }
 
 #[derive(Display)]
+#[allow_multi_line]
+/// Just a basic struct {thing}
+/// and this line should get ignored
+struct HappyStruct2 {
+    thing: &'static str,
+}
+
+#[derive(Display)]
 enum Happy {
     /// I really like Variant1
     Variant1,
@@ -92,6 +100,8 @@ fn does_it_print() {
     );
 
     assert_display(HappyStruct { thing: "hi" }, "Just a basic struct hi");
+
+    assert_display(HappyStruct2 { thing: "hi2" }, "Just a basic struct hi2");
 
     assert_display(inner_mod::InnerHappy::Variant1, "I really like Variant1");
     assert_display(

--- a/tests/no_std/multi_line.stderr
+++ b/tests/no_std/multi_line.stderr
@@ -4,7 +4,7 @@ error: proc-macro derive panicked
 23 | #[derive(Display)]
    |          ^^^^^^^
    |
-   = help: message: Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)
+   = help: message: Multi-line comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive.
 
 error[E0277]: `TestType` doesn't implement `Display`
   --> $DIR/multi_line.rs:34:44

--- a/tests/no_std/multi_line_allow.rs
+++ b/tests/no_std/multi_line_allow.rs
@@ -21,7 +21,7 @@ use displaydoc::Display;
 
 /// this type is pretty swell
 #[derive(Display)]
-#[ignore_multi_line]
+#[ignore_extra_doc_attributes]
 enum TestType {
     /// This one is okay
     Variant1,

--- a/tests/no_std/multi_line_allow.rs
+++ b/tests/no_std/multi_line_allow.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+/// this type is pretty swell
+#[derive(Display)]
+#[allow_multi_line]
+enum TestType {
+    /// This one is okay
+    Variant1,
+
+    /// Multi
+    /// line
+    /// doc.
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/no_std/multi_line_allow.rs
+++ b/tests/no_std/multi_line_allow.rs
@@ -21,7 +21,7 @@ use displaydoc::Display;
 
 /// this type is pretty swell
 #[derive(Display)]
-#[allow_multi_line]
+#[ignore_multi_line]
 enum TestType {
     /// This one is okay
     Variant1,

--- a/tests/std/multi_line.stderr
+++ b/tests/std/multi_line.stderr
@@ -4,7 +4,7 @@ error: proc-macro derive panicked
 23 | #[derive(Display)]
    |          ^^^^^^^
    |
-   = help: message: Multi-line comments are not currently supported by displaydoc. Please consider using block doc comments (/** */)
+   = help: message: Multi-line comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive.
 
 error[E0277]: `TestType` doesn't implement `std::fmt::Display`
   --> $DIR/multi_line.rs:34:44

--- a/tests/std/multi_line_allow.rs
+++ b/tests/std/multi_line_allow.rs
@@ -21,7 +21,7 @@ use displaydoc::Display;
 
 /// this type is pretty swell
 #[derive(Display)]
-#[ignore_multi_line]
+#[ignore_extra_doc_attributes]
 enum TestType {
     /// This one is okay
     Variant1,

--- a/tests/std/multi_line_allow.rs
+++ b/tests/std/multi_line_allow.rs
@@ -1,0 +1,38 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+/// this type is pretty swell
+#[derive(Display)]
+#[allow_multi_line]
+enum TestType {
+    /// This one is okay
+    Variant1,
+
+    /// Multi
+    /// line
+    /// doc.
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/std/multi_line_allow.rs
+++ b/tests/std/multi_line_allow.rs
@@ -21,7 +21,7 @@ use displaydoc::Display;
 
 /// this type is pretty swell
 #[derive(Display)]
-#[allow_multi_line]
+#[ignore_multi_line]
 enum TestType {
     /// This one is okay
     Variant1,


### PR DESCRIPTION
This is a followup to #22 which brings back the old functionality in an opt in manner

cc @Emilgardis and @DianaNites 