### PR TITLE
“enum: variant” with #[prefix_enum_doc_attributes] (resolves #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ pub enum DataStoreError {
     - `/// {var:?}` ⟶ `write!("{:?}", self.var)`
     - `/// {0:?}` ⟶ `write!("{:?}", self.0)`
 
+- Two optional attributes can be added to your types next to the derive:
+
+    - `#[ignore_extra_doc_attributes]` makes the macro ignore any doc
+      comment attributes (or `///` lines) after the first. Multi-line
+      comments using `///` are otherwise treated as an error, so use this
+      attribute or consider switching to block doc comments (`/** */`).
+
+    - `#[prefix_enum_doc_attributes]` combines the doc comment message on
+      your enum itself with the messages for each variant, in the format
+      “enum: variant”. When added to an enum, the doc comment on the enum
+      becomes mandatory. When added to any other type, it has no effect.
+
 <br>
 
 ## FAQ

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -2,9 +2,15 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Attribute, LitStr, Meta, Result};
 
+#[derive(Clone)]
 pub(crate) struct Display {
     pub(crate) fmt: LitStr,
     pub(crate) args: TokenStream,
+}
+
+pub(crate) struct VariantDisplay {
+    pub(crate) r#enum: Option<Display>,
+    pub(crate) variant: Display,
 }
 
 impl ToTokens for Display {
@@ -17,8 +23,19 @@ impl ToTokens for Display {
     }
 }
 
+impl ToTokens for VariantDisplay {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(ref r#enum) = self.r#enum {
+            r#enum.to_tokens(tokens);
+            tokens.extend(quote! { ?; write!(formatter, ": ")?; });
+        }
+        self.variant.to_tokens(tokens);
+    }
+}
+
 pub(crate) struct AttrsHelper {
     ignore_extra_doc_attributes: bool,
+    prefix_enum_doc_attributes: bool,
 }
 
 impl AttrsHelper {
@@ -26,9 +43,13 @@ impl AttrsHelper {
         let ignore_extra_doc_attributes = attrs
             .iter()
             .any(|attr| attr.path.is_ident("ignore_extra_doc_attributes"));
+        let prefix_enum_doc_attributes = attrs
+            .iter()
+            .any(|attr| attr.path.is_ident("prefix_enum_doc_attributes"));
 
         Self {
             ignore_extra_doc_attributes,
+            prefix_enum_doc_attributes,
         }
     }
 
@@ -74,5 +95,19 @@ impl AttrsHelper {
         }
 
         Ok(None)
+    }
+
+    pub(crate) fn display_with_input(&self, r#enum: &[Attribute], variant: &[Attribute]) -> Result<Option<VariantDisplay>> {
+        let r#enum = if self.prefix_enum_doc_attributes {
+            let result = self
+                .display(r#enum)?
+                .expect("Missing doc comment on enum with #[prefix_enum_doc_attributes]. Please remove the attribute or add a doc comment to the enum itself.");
+
+            Some(result)
+        } else {
+            None
+        };
+
+        Ok(self.display(variant)?.map(|variant| VariantDisplay { r#enum, variant }))
     }
 }

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -97,7 +97,11 @@ impl AttrsHelper {
         Ok(None)
     }
 
-    pub(crate) fn display_with_input(&self, r#enum: &[Attribute], variant: &[Attribute]) -> Result<Option<VariantDisplay>> {
+    pub(crate) fn display_with_input(
+        &self,
+        r#enum: &[Attribute],
+        variant: &[Attribute],
+    ) -> Result<Option<VariantDisplay>> {
         let r#enum = if self.prefix_enum_doc_attributes {
             let result = self
                 .display(r#enum)?
@@ -108,6 +112,8 @@ impl AttrsHelper {
             None
         };
 
-        Ok(self.display(variant)?.map(|variant| VariantDisplay { r#enum, variant }))
+        Ok(self
+            .display(variant)?
+            .map(|variant| VariantDisplay { r#enum, variant }))
     }
 }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -104,7 +104,7 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
     let displays = data
         .variants
         .iter()
-        .map(|variant| helper.display(&variant.attrs))
+        .map(|variant| helper.display_with_input(&input.attrs, &variant.attrs))
         .collect::<Result<Vec<_>>>()?;
 
     if displays.iter().any(Option::is_some) {
@@ -119,13 +119,13 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
                 Ok(match &variant.fields {
                     Fields::Named(fields) => {
                         let var = fields.named.iter().map(|field| &field.ident);
-                        quote!(#ty::#ident { #(#var),* } => #display)
+                        quote!(#ty::#ident { #(#var),* } => { #display })
                     }
                     Fields::Unnamed(fields) => {
                         let var = (0..fields.unnamed.len()).map(|i| format_ident!("_{}", i));
-                        quote!(#ty::#ident(#(#var),*) => #display)
+                        quote!(#ty::#ident(#(#var),*) => { #display })
                     }
-                    Fields::Unit => quote!(#ty::#ident => #display),
+                    Fields::Unit => quote!(#ty::#ident => { #display }),
                 })
             })
             .collect::<Result<Vec<_>>>()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,18 @@
 //!     - `/// {var:?}` ⟶ `write!("{:?}", self.var)`
 //!     - `/// {0:?}` ⟶ `write!("{:?}", self.0)`
 //!
+//! - Two optional attributes can be added to your types next to the derive:
+//!
+//!     - `#[ignore_extra_doc_attributes]` makes the macro ignore any doc
+//!       comment attributes (or `///` lines) after the first. Multi-line
+//!       comments using `///` are otherwise treated as an error, so use this
+//!       attribute or consider switching to block doc comments (`/** */`).
+//!
+//!     - `#[prefix_enum_doc_attributes]` combines the doc comment message on
+//!       your enum itself with the messages for each variant, in the format
+//!       “enum: variant”. When added to an enum, the doc comment on the enum
+//!       becomes mandatory. When added to any other type, it has no effect.
+//!
 //! <br>
 //!
 //! ## FAQ
@@ -94,7 +106,10 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derive macro for implementing `Display` via doc comment attributes
-#[proc_macro_derive(Display, attributes(ignore_extra_doc_attributes))]
+#[proc_macro_derive(Display, attributes(
+    ignore_extra_doc_attributes,
+    prefix_enum_doc_attributes,
+))]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,10 +106,10 @@ use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Derive macro for implementing `Display` via doc comment attributes
-#[proc_macro_derive(Display, attributes(
-    ignore_extra_doc_attributes,
-    prefix_enum_doc_attributes,
-))]
+#[proc_macro_derive(
+    Display,
+    attributes(ignore_extra_doc_attributes, prefix_enum_doc_attributes,)
+)]
 pub fn derive_error(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/tests/compile_tests.rs
+++ b/tests/compile_tests.rs
@@ -9,12 +9,20 @@ fn no_std() {
     t.compile_fail("tests/no_std/multi_line.rs");
     #[cfg(not(feature = "std"))]
     t.pass("tests/no_std/multi_line_allow.rs");
+    #[cfg(not(feature = "std"))]
+    t.compile_fail("tests/no_std/enum_prefix_missing.rs");
+    #[cfg(not(feature = "std"))]
+    t.pass("tests/no_std/enum_prefix.rs");
     #[cfg(feature = "std")]
     t.compile_fail("tests/std/without.rs");
     #[cfg(feature = "std")]
     t.compile_fail("tests/std/multi_line.rs");
     #[cfg(feature = "std")]
     t.pass("tests/std/multi_line_allow.rs");
+    #[cfg(feature = "std")]
+    t.compile_fail("tests/std/enum_prefix_missing.rs");
+    #[cfg(feature = "std")]
+    t.pass("tests/std/enum_prefix.rs");
     #[cfg(feature = "std")]
     t.pass("tests/std/multiple.rs");
     t.pass("tests/no_std/with.rs");

--- a/tests/no_std/enum_prefix.rs
+++ b/tests/no_std/enum_prefix.rs
@@ -1,0 +1,36 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+/// this type is pretty swell
+#[derive(Display)]
+#[prefix_enum_doc_attributes]
+enum TestType {
+    /// this variant is too
+    Variant1,
+
+    /// this variant is two
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/no_std/enum_prefix_missing.rs
+++ b/tests/no_std/enum_prefix_missing.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+#[derive(Display)]
+#[prefix_enum_doc_attributes]
+enum TestType {
+    /// this variant is too
+    Variant1,
+
+    /// this variant is two
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/no_std/enum_prefix_missing.stderr
+++ b/tests/no_std/enum_prefix_missing.stderr
@@ -1,0 +1,19 @@
+error: proc-macro derive panicked
+  --> $DIR/enum_prefix_missing.rs:22:10
+   |
+22 | #[derive(Display)]
+   |          ^^^^^^^
+   |
+   = help: message: Missing doc comment on enum with #[prefix_enum_doc_attributes]. Please remove the attribute or add a doc comment to the enum itself.
+
+error[E0277]: `TestType` doesn't implement `Display`
+  --> $DIR/enum_prefix_missing.rs:32:44
+   |
+32 | static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+   | -------------------------------------------^^^^^^^^----------------------
+   | |                                          |
+   | |                                          `TestType` cannot be formatted with the default formatter
+   | required by this bound in `assert_impl_all`
+   |
+   = help: the trait `Display` is not implemented for `TestType`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead

--- a/tests/std/enum_prefix.rs
+++ b/tests/std/enum_prefix.rs
@@ -1,0 +1,36 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+/// this type is pretty swell
+#[derive(Display)]
+#[prefix_enum_doc_attributes]
+enum TestType {
+    /// this variant is too
+    Variant1,
+
+    /// this variant is two
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/std/enum_prefix_missing.rs
+++ b/tests/std/enum_prefix_missing.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(not(feature = "std"), feature(lang_items, start))]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg_attr(not(feature = "std"), start)]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}
+#[lang = "eh_personality"]
+#[no_mangle]
+#[cfg(not(feature = "std"))]
+pub extern "C" fn rust_eh_personality() {}
+#[panic_handler]
+#[cfg(not(feature = "std"))]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe {
+        libc::abort();
+    }
+}
+
+use displaydoc::Display;
+
+#[derive(Display)]
+#[prefix_enum_doc_attributes]
+enum TestType {
+    /// this variant is too
+    Variant1,
+
+    /// this variant is two
+    Variant2,
+}
+
+static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+
+#[cfg(feature = "std")]
+fn main() {}

--- a/tests/std/enum_prefix_missing.stderr
+++ b/tests/std/enum_prefix_missing.stderr
@@ -1,0 +1,19 @@
+error: proc-macro derive panicked
+  --> $DIR/enum_prefix_missing.rs:22:10
+   |
+22 | #[derive(Display)]
+   |          ^^^^^^^
+   |
+   = help: message: Missing doc comment on enum with #[prefix_enum_doc_attributes]. Please remove the attribute or add a doc comment to the enum itself.
+
+error[E0277]: `TestType` doesn't implement `std::fmt::Display`
+  --> $DIR/enum_prefix_missing.rs:32:44
+   |
+32 | static_assertions::assert_impl_all!(label; TestType, core::fmt::Display);
+   | -------------------------------------------^^^^^^^^----------------------
+   | |                                          |
+   | |                                          `TestType` cannot be formatted with the default formatter
+   | required by this bound in `assert_impl_all`
+   |
+   = help: the trait `std::fmt::Display` is not implemented for `TestType`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead


### PR DESCRIPTION
This patch adds support for combining an enum’s doc message with each variant like “enum: variant”.

The helper attribute currently does nothing when applied to non-enum types, and treats an enum without any doc attributes as an error (to catch accidents), but I don’t feel too strongly about these choices.

I’ve tested my changes under 1.31.0 and nightly-2021-06-20.