### PR TITLE
Fix clippy::use_self for enums

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -384,13 +384,13 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
                 Ok(match &variant.fields {
                     Fields::Named(fields) => {
                         let var = fields.named.iter().map(|field| &field.ident);
-                        quote!(#ty::#ident { #(#var),* } => { #display })
+                        quote!(Self::#ident { #(#var),* } => { #display })
                     }
                     Fields::Unnamed(fields) => {
                         let var = (0..fields.unnamed.len()).map(|i| format_ident!("_{}", i));
-                        quote!(#ty::#ident(#(#var),*) => { #display })
+                        quote!(Self::#ident(#(#var),*) => { #display })
                     }
-                    Fields::Unit => quote!(#ty::#ident => { #display }),
+                    Fields::Unit => quote!(Self::#ident => { #display }),
                 })
             })
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
With rust `1.61.0` came `0.1.61`, which activated [`use_self`](https://rust-lang.github.io/rust-clippy/master/index.html#use_self), resulting in errors like the one below:

```
warning: unnecessary structure name repetition
  --> src/database/error.rs:10:10
   |
10 | pub enum Error {
   |          ^^^^^ help: use the applicable keyword: `Self`
   |
note: the lint level is defined here
  --> src/lib.rs:24:5
   |
24 |     clippy::nursery,
   |     ^^^^^^^^^^^^^^^
   = note: `#[warn(clippy::use_self)]` implied by `#[warn(clippy::nursery)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#use_self
```