### PR TITLE
Update syn requirement to 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.45.0
+          - 1.56.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.45.0
+          - 1.56.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -87,7 +87,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.45.0
+          - 1.56.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-syn = "1.0"
+syn = "2.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library provides a convenient derive macro for the standard library's
 displaydoc = "0.2"
 ```
 
-*Compiler support: requires rustc 1.45+*
+*Compiler support: requires rustc 1.56+*
 
 <br>
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -42,10 +42,10 @@ impl AttrsHelper {
     pub(crate) fn new(attrs: &[Attribute]) -> Self {
         let ignore_extra_doc_attributes = attrs
             .iter()
-            .any(|attr| attr.path.is_ident("ignore_extra_doc_attributes"));
+            .any(|attr| attr.path().is_ident("ignore_extra_doc_attributes"));
         let prefix_enum_doc_attributes = attrs
             .iter()
-            .any(|attr| attr.path.is_ident("prefix_enum_doc_attributes"));
+            .any(|attr| attr.path().is_ident("prefix_enum_doc_attributes"));
 
         Self {
             ignore_extra_doc_attributes,
@@ -54,7 +54,7 @@ impl AttrsHelper {
     }
 
     pub(crate) fn display(&self, attrs: &[Attribute]) -> Result<Option<Display>> {
-        let displaydoc_attr = attrs.iter().find(|attr| attr.path.is_ident("displaydoc"));
+        let displaydoc_attr = attrs.iter().find(|attr| attr.path().is_ident("displaydoc"));
 
         if let Some(displaydoc_attr) = displaydoc_attr {
             let lit = displaydoc_attr
@@ -71,7 +71,7 @@ impl AttrsHelper {
 
         let num_doc_attrs = attrs
             .iter()
-            .filter(|attr| attr.path.is_ident("doc"))
+            .filter(|attr| attr.path().is_ident("doc"))
             .count();
 
         if !self.ignore_extra_doc_attributes && num_doc_attrs > 1 {
@@ -79,11 +79,14 @@ impl AttrsHelper {
         }
 
         for attr in attrs {
-            if attr.path.is_ident("doc") {
-                let meta = attr.parse_meta()?;
-                let lit = match meta {
+            if attr.path().is_ident("doc") {
+                let lit = match &attr.meta {
                     Meta::NameValue(syn::MetaNameValue {
-                        lit: syn::Lit::Str(lit),
+                        value:
+                            syn::Expr::Lit(syn::ExprLit {
+                                lit: syn::Lit::Str(lit),
+                                ..
+                            }),
                         ..
                     }) => lit,
                     _ => unimplemented!(),

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -3,7 +3,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{
     punctuated::Punctuated,
-    token::{Add, Colon, Colon2, Comma, Where},
+    token::{Colon, Comma, PathSep, Plus, Where},
     Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Generics, Ident, Path, PathArguments,
     PathSegment, PredicateType, Result, TraitBound, TraitBoundModifier, Type, TypeParam,
     TypeParamBound, TypePath, WhereClause, WherePredicate,
@@ -110,7 +110,7 @@ fn impl_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
 
 /// Create a `where` predicate for `ident`, without any [bound][TypeParamBound]s yet.
 fn new_empty_where_type_predicate(ident: Ident) -> PredicateType {
-    let mut path_segments = Punctuated::<PathSegment, Colon2>::new();
+    let mut path_segments = Punctuated::<PathSegment, PathSep>::new();
     path_segments.push_value(PathSegment {
         ident,
         arguments: PathArguments::None,
@@ -127,7 +127,7 @@ fn new_empty_where_type_predicate(ident: Ident) -> PredicateType {
         colon_token: Colon {
             spans: [Span::call_site()],
         },
-        bounds: Punctuated::<TypeParamBound, Add>::new(),
+        bounds: Punctuated::<TypeParamBound, Plus>::new(),
     }
 }
 
@@ -149,14 +149,14 @@ enum UseGlobalPrefix {
 
 /// Create a path with segments composed of [Idents] *without* any [PathArguments].
 fn join_paths(name_segments: &[&str], use_global_prefix: UseGlobalPrefix) -> Path {
-    let mut segments = Punctuated::<PathSegment, Colon2>::new();
+    let mut segments = Punctuated::<PathSegment, PathSep>::new();
     assert!(!name_segments.is_empty());
     segments.push_value(PathSegment {
         ident: Ident::new(name_segments[0], Span::call_site()),
         arguments: PathArguments::None,
     });
     for name in name_segments[1..].iter() {
-        segments.push_punct(Colon2 {
+        segments.push_punct(PathSep {
             spans: [Span::call_site(), Span::mixed_site()],
         });
         segments.push_value(PathSegment {
@@ -166,7 +166,7 @@ fn join_paths(name_segments: &[&str], use_global_prefix: UseGlobalPrefix) -> Pat
     }
     Path {
         leading_colon: match use_global_prefix {
-            UseGlobalPrefix::LeadingColon => Some(Colon2 {
+            UseGlobalPrefix::LeadingColon => Some(PathSep {
                 spans: [Span::call_site(), Span::mixed_site()],
             }),
             UseGlobalPrefix::NoLeadingColon => None,
@@ -205,7 +205,7 @@ fn add_display_constraint_to_type_predicate(
         path: display_path,
     });
     if !predicate_that_needs_a_display_impl.bounds.is_empty() {
-        predicate_that_needs_a_display_impl.bounds.push_punct(Add {
+        predicate_that_needs_a_display_impl.bounds.push_punct(Plus {
             spans: [Span::call_site()],
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! displaydoc = "0.2"
 //! ```
 //!
-//! *Compiler support: requires rustc 1.45+*
+//! *Compiler support: requires rustc 1.56+*
 //!
 //! <br>
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
Update to syn 2.0.  The [MSRV for syn is 1.56](https://github.com/dtolnay/syn/blob/master/Cargo.toml#L21), so I bumped it here as well.