### PR TITLE
Reference _the_ core module

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -48,17 +48,17 @@ fn specialization() -> TokenStream {
         extern crate std;
 
         trait PathToDisplayDoc {
-            fn __displaydoc_display(&self) -> ::std::path::Display<'_>;
+            fn __displaydoc_display(&self) -> std::path::Display<'_>;
         }
 
-        impl PathToDisplayDoc for ::std::path::Path {
-            fn __displaydoc_display(&self) -> ::std::path::Display<'_> {
+        impl PathToDisplayDoc for std::path::Path {
+            fn __displaydoc_display(&self) -> std::path::Display<'_> {
                 self.display()
             }
         }
 
-        impl PathToDisplayDoc for ::std::path::PathBuf {
-            fn __displaydoc_display(&self) -> ::std::path::Display<'_> {
+        impl PathToDisplayDoc for std::path::PathBuf {
+            fn __displaydoc_display(&self) -> std::path::Display<'_> {
                 self.display()
             }
         }

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -35,7 +35,7 @@ fn specialization() -> TokenStream {
             fn __displaydoc_display(&self) -> Self;
         }
 
-        impl<T: core::fmt::Display> DisplayToDisplayDoc for &T {
+        impl<T: ::core::fmt::Display> DisplayToDisplayDoc for &T {
             fn __displaydoc_display(&self) -> Self {
                 self
             }
@@ -48,17 +48,17 @@ fn specialization() -> TokenStream {
         extern crate std;
 
         trait PathToDisplayDoc {
-            fn __displaydoc_display(&self) -> std::path::Display<'_>;
+            fn __displaydoc_display(&self) -> ::std::path::Display<'_>;
         }
 
-        impl PathToDisplayDoc for std::path::Path {
-            fn __displaydoc_display(&self) -> std::path::Display<'_> {
+        impl PathToDisplayDoc for ::std::path::Path {
+            fn __displaydoc_display(&self) -> ::std::path::Display<'_> {
                 self.display()
             }
         }
 
-        impl PathToDisplayDoc for std::path::PathBuf {
-            fn __displaydoc_display(&self) -> std::path::Display<'_> {
+        impl PathToDisplayDoc for ::std::path::PathBuf {
+            fn __displaydoc_display(&self) -> ::std::path::Display<'_> {
                 self.display()
             }
         }
@@ -90,8 +90,8 @@ fn impl_struct(input: &DeriveInput, data: &DataStruct) -> Result<TokenStream> {
             Fields::Unit => quote!(_),
         };
         quote! {
-            impl #impl_generics core::fmt::Display for #ty #ty_generics #where_clause {
-                fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+            impl #impl_generics ::core::fmt::Display for #ty #ty_generics #where_clause {
+                fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     // NB: This destructures the fields of `self` into named variables (for unnamed
                     // fields, it uses _0, _1, etc as above). The `#[allow(unused_variables)]`
                     // section means it doesn't have to parse the individual field references out of
@@ -365,8 +365,8 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
 
     if data.variants.is_empty() {
         Ok(quote! {
-            impl #impl_generics core::fmt::Display for #ty #ty_generics #where_clause {
-                fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+            impl #impl_generics ::core::fmt::Display for #ty #ty_generics #where_clause {
+                fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     unreachable!("empty enums cannot be instantiated and thus cannot be printed")
                 }
             }
@@ -394,8 +394,8 @@ fn impl_enum(input: &DeriveInput, data: &DataEnum) -> Result<TokenStream> {
             })
             .collect::<Result<Vec<_>>>()?;
         Ok(quote! {
-            impl #impl_generics core::fmt::Display for #ty #ty_generics #where_clause {
-                fn fmt(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+            impl #impl_generics ::core::fmt::Display for #ty #ty_generics #where_clause {
+                fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #[allow(unused_variables)]
                     match self {
                         #(#arms,)*


### PR DESCRIPTION
This PR allows using `displaydoc` in modules that define a `core` submodule. An example of this is [`probe-rs's ARM implementation`](https://github.com/probe-rs/probe-rs/blob/a3427721fc6d922dfb900724d967e04339388d2b/probe-rs/src/architecture/arm/mod.rs#L6)