### PR TITLE
Bump to 0.2.5, edition 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+# [0.2.5] - 2024-06-20
+
+# Changed
+ - Don't name the output of the const block to work around `non_local_definitions` error (#47)
+ - Reference the `core` crate correctly to avoid clashes with modules named `core` (#45)
+ - Explicitly list MSRV in Cargo.toml (#51)
+ - Bump edition to 2021 (#51)
+
 # [0.2.4] - 2022-05-02
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
+rust-version = "1.56.0"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/yaahc/displaydoc"


### PR DESCRIPTION
Primarily brings in the fix for the nightly breakage in #47.

Also includes https://github.com/yaahc/displaydoc/pull/45 to make this crate a bit more usable in cases with conflicting module names.

Finally, this switches the crate to edition 2021 since that's already compatible with the MSRV.