### PR TITLE
Use "paragraph breaks" in error message

### DIFF
--- a/src/attr.rs
+++ b/src/attr.rs
@@ -107,7 +107,7 @@ impl AttrsHelper {
         } else {
             strs.collect::<Option<Vec<_>>>()
         }.unwrap_or_else(|| {
-            panic!("Line breaks in multi-line doc comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive");
+            panic!("Paragraph breaks in multi-line doc comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive");
         }).join(" ");
 
         let mut display = Display {

--- a/tests/ui/multi_line_line_break.stderr
+++ b/tests/ui/multi_line_line_break.stderr
@@ -4,7 +4,7 @@ error: proc-macro derive panicked
 3 | #[derive(Display)]
   |          ^^^^^^^
   |
-  = help: message: Line breaks in multi-line doc comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive
+  = help: message: Paragraph breaks in multi-line doc comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive
 
 error[E0277]: `TestType` doesn't implement `std::fmt::Display`
   --> tests/ui/multi_line_line_break.rs:18:37

--- a/tests/ui/multi_line_line_break_block.stderr
+++ b/tests/ui/multi_line_line_break_block.stderr
@@ -4,7 +4,7 @@ error: proc-macro derive panicked
 3 | #[derive(Display)]
   |          ^^^^^^^
   |
-  = help: message: Line breaks in multi-line doc comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive
+  = help: message: Paragraph breaks in multi-line doc comments are disabled by default by displaydoc. Please consider using block doc comments (/** */) or adding the #[ignore_extra_doc_attributes] attribute to your type next to the derive
 
 error[E0277]: `TestType` doesn't implement `std::fmt::Display`
   --> tests/ui/multi_line_line_break_block.rs:12:37


### PR DESCRIPTION
A double line break in markdown is rendered as a paragraph break. This error does not occur for single line breaks.

Instead of the confusing "double line break" I opted for the unambiguous "paragraph break" since it's clearer about what it is in Markdown terms.