### PR TITLE
Upgrade syn to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.56.0
+          - 1.71.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -22,16 +22,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - name: Downgrade deps for MSRV
-        if: ${{ matrix.rust == '1.56.0' }}
+        if: ${{ matrix.rust == '1.71.0' }}
         run: |
-          cargo update -p libc --precise 0.2.160
-          cargo update -p pretty_assertions --precise 1.4.0
-          cargo update -p proc-macro2 --precise 1.0.101
-          cargo update -p quote --precise 1.0.40
-          cargo update -p unicode-ident --precise 1.0.8
-          cargo update -p itoa --precise 1.0.9
-          cargo update -p ryu --precise 1.0.13
-          cargo update -p glob --precise 0.3.2
+          cargo update -p trybuild --precise 1.0.111
+          cargo update -p indexmap --precise 2.13.1
+          cargo update -p toml --precise 0.9.6
+          cargo update -p toml_datetime --precise 0.7.1
+          cargo update -p toml_parser --precise 1.0.2
+          cargo update -p toml_writer --precise 1.0.2
+          cargo update -p serde_spanned --precise 1.0.1
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -72,7 +71,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0
+          - 1.71.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -80,17 +79,15 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
       - uses: Swatinem/rust-cache@v1
-
       - name: Downgrade deps for MSRV
         run: |
-          cargo update -p libc --precise 0.2.160
-          cargo update -p pretty_assertions --precise 1.4.0
-          cargo update -p proc-macro2 --precise 1.0.101
-          cargo update -p quote --precise 1.0.40
-          cargo update -p unicode-ident --precise 1.0.8
-          cargo update -p itoa --precise 1.0.9
-          cargo update -p ryu --precise 1.0.13
-          cargo update -p glob --precise 0.3.2
+          cargo update -p trybuild --precise 1.0.111
+          cargo update -p indexmap --precise 2.13.1
+          cargo update -p toml --precise 0.9.6
+          cargo update -p toml_datetime --precise 0.7.1
+          cargo update -p toml_parser --precise 1.0.2
+          cargo update -p toml_writer --precise 1.0.2
+          cargo update -p serde_spanned --precise 1.0.1
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -106,7 +103,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.56.0
+          - 1.71.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased] - ReleaseDate
 
+## Added
+- Updated `syn` dependency to 3.0
+
+## Changed
+- Bumped MSRV to 1.71
+
 # [0.2.6] - 2026-05-27
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "displaydoc"
 version = "0.2.6"
-rust-version = "1.56.0"
+rust-version = "1.71.0"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -24,7 +24,7 @@ default = ["std"]
 std = []
 
 [dependencies]
-syn = "2.0"
+syn = "3.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library provides a convenient derive macro for the standard library's
 displaydoc = "0.2"
 ```
 
-*Compiler support: requires rustc 1.56+*
+*Compiler support: requires rustc 1.71+*
 
 <br>
 

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -99,7 +99,7 @@ impl AttrsHelper {
                 .join("\n")
                 .trim()
                 .to_string();
-            (!doc_str.is_empty()).then(|| doc_str)
+            (!doc_str.is_empty()).then_some(doc_str)
         });
 
         let joined = if self.ignore_extra_doc_attributes {

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -5,7 +5,7 @@ use syn::{
     punctuated::Punctuated,
     token::{Colon, Comma, PathSep, Plus, Where},
     Data, DataEnum, DataStruct, DeriveInput, Error, Fields, Generics, Ident, Path, PathArguments,
-    PathSegment, PredicateType, Result, TraitBound, TraitBoundModifier, Type, TypeParam,
+    PathSegment, PredicateType, Result, TraitBound, TraitBoundModifiers, Type, TypeParam,
     TypeParamBound, TypePath, WhereClause, WherePredicate,
 };
 
@@ -116,8 +116,10 @@ fn new_empty_where_type_predicate(ident: Ident) -> PredicateType {
         arguments: PathArguments::None,
     });
     PredicateType {
+        attrs: Vec::new(),
         lifetimes: None,
         bounded_ty: Type::Path(TypePath {
+            attrs: Vec::new(),
             qself: None,
             path: Path {
                 leading_colon: None,
@@ -200,8 +202,9 @@ fn add_display_constraint_to_type_predicate(
 
     let display_bound = TypeParamBound::Trait(TraitBound {
         paren_token: None,
-        modifier: TraitBoundModifier::None,
         lifetimes: None,
+        modifiers: TraitBoundModifiers::default(),
+        maybe: None,
         path: display_path,
     });
     if !predicate_that_needs_a_display_impl.bounds.is_empty() {
@@ -249,7 +252,11 @@ fn extract_trait_constraints_from_source(
         // We only care about type and not lifetime constraints here.
         if let WherePredicate::Type(ref pred_ty) = predicate {
             let ident = match &pred_ty.bounded_ty {
-                Type::Path(TypePath { path, qself: None }) => match path.get_ident() {
+                Type::Path(TypePath {
+                    path,
+                    qself: None,
+                    attrs: _,
+                }) => match path.get_ident() {
                     None => continue,
                     Some(ident) => ident,
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! displaydoc = "0.2"
 //! ```
 //!
-//! *Compiler support: requires rustc 1.56+*
+//! *Compiler support: requires rustc 1.71+*
 //!
 //! <br>
 //!


### PR DESCRIPTION
Closes https://github.com/yaahc/displaydoc/issues/65

- Update syn to 3.0
- Bumped MSRV to 1.71
  - Fixed a new clippy lint
  - Fixed pinned dependancies in CI